### PR TITLE
Fix widget titles and typo in config

### DIFF
--- a/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
@@ -78,7 +78,7 @@ public final class ScmStatsPlugin extends SonarPlugin {
 
             PropertyDefinition.builder(ScmStatsConstants.PERIOD_3).
               defaultValue("0").
-              name("Period #2").
+              name("Period #3").
               description("See description of Period #1 property. If it's set to a non-positive value, then it's ignored").
               index(3).
               onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE).

--- a/src/main/resources/org/sonar/plugins/scmstats/authors_activity_widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/scmstats/authors_activity_widget.html.erb
@@ -2,7 +2,9 @@
 
 widgetPeriod = widget_properties["Period"]
 days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
-
+if days == nil
+  days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
+end
 if widgetPeriod == 1
   period_measure = "scm-commits-per-user"
 else 

--- a/src/main/resources/org/sonar/plugins/scmstats/commits_per_clockhour_widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/scmstats/commits_per_clockhour_widget.html.erb
@@ -2,6 +2,9 @@
  
 widgetPeriod = widget_properties["Period"]
 days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
+if days == nil
+  days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
+end
 if widgetPeriod == 1
   period_measure = "scm-commits-per-clockhour"
 else 

--- a/src/main/resources/org/sonar/plugins/scmstats/commits_per_month_widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/scmstats/commits_per_month_widget.html.erb
@@ -1,6 +1,9 @@
 <% 
 widgetPeriod = widget_properties["Period"]
 days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
+if days == nil
+  days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
+end
 if widgetPeriod == 1
   period_measure = "scm-commits-per-month"
 else 

--- a/src/main/resources/org/sonar/plugins/scmstats/commits_per_user_widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/scmstats/commits_per_user_widget.html.erb
@@ -1,6 +1,9 @@
 <% 
 widgetPeriod = widget_properties["Period"]
 days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
+if days == nil
+  days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
+end
 if widgetPeriod == 1
   period_measure = "scm-commits-per-user"
 else 

--- a/src/main/resources/org/sonar/plugins/scmstats/commits_per_weekday_widget.html.erb
+++ b/src/main/resources/org/sonar/plugins/scmstats/commits_per_weekday_widget.html.erb
@@ -1,6 +1,9 @@
 <% 
 widgetPeriod = widget_properties["Period"]
 days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
+if days == nil
+  days = Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
+end
 if widgetPeriod == 1
   period_measure = "scm-commits-per-weekday"
 else 


### PR DESCRIPTION
In the project of my company we had an issue with the sonar-scm-stats plugin. Although we set Period #2 to 30 days and configured the widgets to use Period #2 the titles of the widgets were "... from the beginning of the project". A look into our sonar database revealed that the property sonar.scm-stats.period2 in the properties table has a resource_id of NULL. Thus the property could not be read from the widget.html.erb-files by 
```ruby
Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, @resource.id)
```
So I added a fallback to look for 
```ruby
Property.value('sonar.scm-stats.period' + widgetPeriod.to_s, nil)
```
if the first attempt with resource_id leads to a nil-result.

If the root problem is our database having a resource_id of NULL for the properties, then you can ignore this fix.

This pull-request also contains the fix to a small typo: The "Period #3" in the config page was named "Period #2".